### PR TITLE
Obgc obc seg data update period

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -262,9 +262,9 @@ type, public :: MOM_control_struct ; private
                                      !! calculated, and if it is 0, dtbt is calculated every step.
   type(time_type) :: dtbt_reset_interval !< A time_time representation of dtbt_reset_period.
   type(time_type) :: dtbt_reset_time !< The next time DTBT should be calculated.
-  real            :: update_OBC_period!< The maximum allowed time interval between OBC updates
-  type(time_type) :: update_OBC_interval !< A time_time representation of update_OBC_period.
-  type(time_type) :: update_OBC_time !< The next time OBC is applied.
+  real            :: dt_obc_seg_period!< The time interval between OBC segment updates for OBGC tracers
+  type(time_type) :: dt_obc_seg_interval !< A time_time representation of dt_obc_seg_period.
+  type(time_type) :: dt_obc_seg_time !< The next time OBC segment update is applied to OBGC tracers.
 
   real, dimension(:,:), pointer :: frac_shelf_h => NULL() !< fraction of total area occupied
                                      !! by ice shelf [nondim]
@@ -1061,11 +1061,11 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
     !OBC segment data update for some fields can be less frequent than others 
     if(associated(CS%OBC)) then
       CS%OBC%update_OBC_seg_data = .false.
-      if (CS%update_OBC_period == 0.0) CS%OBC%update_OBC_seg_data = .true.
-      if (CS%update_OBC_period > 0.0) then
-       if (Time_local >= CS%update_OBC_time) then  !### Change >= to > here.
+      if (CS%dt_obc_seg_period == 0.0) CS%OBC%update_OBC_seg_data = .true.
+      if (CS%dt_obc_seg_period > 0.0) then
+       if (Time_local >= CS%dt_obc_seg_time) then  !### Change >= to > here.
         CS%OBC%update_OBC_seg_data = .true.
-        CS%update_OBC_time = CS%update_OBC_time + CS%update_OBC_interval
+        CS%dt_obc_seg_time = CS%dt_obc_seg_time + CS%dt_obc_seg_interval
        endif
       endif
     endif
@@ -1940,14 +1940,11 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "is set by DT_THERM.  This is only used if SPLIT is true.", &
                  units="s", default=default_val, do_not_read=(dtbt > 0.0))
 
-    CS%update_OBC_period = -1.0
-    call get_param(param_file, "MOM", "UPDATE_OBC_PERIOD_MAX", CS%update_OBC_period, &
-                 "The maximum period between OBC segment data updates. "//&
-                 "If UPDATE_OBC_PERIOD_MAX  is negative, DTBT is set based "//&
-                 "only on information available at initialization.  If 0, "//&
-                 "OBC updates every dynamics time step. The default "//&
-                 "is set by DT_THERM.  This is only used if SPLIT is true.", &
-                 units="s", default=default_val, do_not_read=(dtbt > 0.0))
+    CS%dt_obc_seg_period = -1.0
+    call get_param(param_file, "MOM", "DT_OBC_SEG_UPDATE_OBGC", CS%dt_obc_seg_period, &
+                 "The time between OBC segment data updates for OBGC tracers. "//&
+                 "The default is set to DT.  This is only used if SPLIT is true.", &
+                 units="s", default=CS%dt)
      
   endif
 
@@ -2648,16 +2645,16 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
       endif
     endif
     !Set OBC segment data update period
-    if (associated(CS%OBC) .and. CS%update_OBC_period > 0.0) then
-      CS%update_OBC_interval = real_to_time(CS%update_OBC_period)
-      ! Set update_OBC_time to be the next even multiple of update_OBC_interval.
-      CS%update_OBC_time = Time_init + CS%update_OBC_interval * &
-                                 ((Time - Time_init) / CS%update_OBC_interval)
-      if ((CS%update_OBC_time > Time) .and. CS%OBC%update_OBC) then
+    if (associated(CS%OBC) .and. CS%dt_obc_seg_period > 0.0) then
+      CS%dt_obc_seg_interval = real_to_time(CS%dt_obc_seg_period)
+      ! Set dt_obc_seg_time to be the next even multiple of dt_obc_seg_interval.
+      CS%dt_obc_seg_time = Time_init + CS%dt_obc_seg_interval * &
+                                 ((Time - Time_init) / CS%dt_obc_seg_interval)
+      if ((CS%dt_obc_seg_time > Time) .and. CS%OBC%update_OBC_seg_data) then
         ! Back up dtbt_reset_time one interval to force dtbt to be calculated,
         ! because the restart was not aligned with the interval to recalculate
         ! dtbt, and dtbt was not read from a restart file.
-        CS%update_OBC_time = CS%update_OBC_time - CS%update_OBC_interval
+        CS%dt_obc_seg_time = CS%dt_obc_seg_time - CS%dt_obc_seg_interval
       endif
     endif
   elseif (CS%use_RK2) then

--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -262,6 +262,10 @@ type, public :: MOM_control_struct ; private
                                      !! calculated, and if it is 0, dtbt is calculated every step.
   type(time_type) :: dtbt_reset_interval !< A time_time representation of dtbt_reset_period.
   type(time_type) :: dtbt_reset_time !< The next time DTBT should be calculated.
+  real            :: update_OBC_period!< The maximum allowed time interval between OBC updates
+  type(time_type) :: update_OBC_interval !< A time_time representation of update_OBC_period.
+  type(time_type) :: update_OBC_time !< The next time OBC is applied.
+
   real, dimension(:,:), pointer :: frac_shelf_h => NULL() !< fraction of total area occupied
                                      !! by ice shelf [nondim]
   real, dimension(:,:,:), pointer :: &
@@ -1052,6 +1056,17 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
       if (Time_local >= CS%dtbt_reset_time) then  !### Change >= to > here.
         calc_dtbt = .true.
         CS%dtbt_reset_time = CS%dtbt_reset_time + CS%dtbt_reset_interval
+      endif
+    endif
+    !OBC segment data update for some fields can be less frequent than others 
+    if(associated(CS%OBC)) then
+      CS%OBC%update_OBC_seg_data = .false.
+      if (CS%update_OBC_period == 0.0) CS%OBC%update_OBC_seg_data = .true.
+      if (CS%update_OBC_period > 0.0) then
+       if (Time_local >= CS%update_OBC_time) then  !### Change >= to > here.
+        CS%OBC%update_OBC_seg_data = .true.
+        CS%update_OBC_time = CS%update_OBC_time + CS%update_OBC_interval
+       endif
       endif
     endif
 
@@ -1924,6 +1939,16 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "DTBT will be set every dynamics time step. The default "//&
                  "is set by DT_THERM.  This is only used if SPLIT is true.", &
                  units="s", default=default_val, do_not_read=(dtbt > 0.0))
+
+    CS%update_OBC_period = -1.0
+    call get_param(param_file, "MOM", "UPDATE_OBC_PERIOD_MAX", CS%update_OBC_period, &
+                 "The maximum period between OBC segment data updates. "//&
+                 "If UPDATE_OBC_PERIOD_MAX  is negative, DTBT is set based "//&
+                 "only on information available at initialization.  If 0, "//&
+                 "OBC updates every dynamics time step. The default "//&
+                 "is set by DT_THERM.  This is only used if SPLIT is true.", &
+                 units="s", default=default_val, do_not_read=(dtbt > 0.0))
+     
   endif
 
   ! This is here in case these values are used inappropriately.
@@ -2620,6 +2645,19 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
         ! because the restart was not aligned with the interval to recalculate
         ! dtbt, and dtbt was not read from a restart file.
         CS%dtbt_reset_time = CS%dtbt_reset_time - CS%dtbt_reset_interval
+      endif
+    endif
+    !Set OBC segment data update period
+    if (associated(CS%OBC) .and. CS%update_OBC_period > 0.0) then
+      CS%update_OBC_interval = real_to_time(CS%update_OBC_period)
+      ! Set update_OBC_time to be the next even multiple of update_OBC_interval.
+      CS%update_OBC_time = Time_init + CS%update_OBC_interval * &
+                                 ((Time - Time_init) / CS%update_OBC_interval)
+      if ((CS%update_OBC_time > Time) .and. CS%OBC%update_OBC) then
+        ! Back up dtbt_reset_time one interval to force dtbt to be calculated,
+        ! because the restart was not aligned with the interval to recalculate
+        ! dtbt, and dtbt was not read from a restart file.
+        CS%update_OBC_time = CS%update_OBC_time - CS%update_OBC_interval
       endif
     endif
   elseif (CS%use_RK2) then

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -241,6 +241,8 @@ type, public :: ocean_OBC_type
   logical :: user_BCs_set_globally = .false.          !< True if any OBC_USER_CONFIG is set
                                                       !! for input from user directory.
   logical :: update_OBC = .false.                     !< Is OBC data time-dependent
+  logical :: update_OBC_seg_data = .false.           !< Is it the time for OBC segment data update for fields that 
+                                                      !! require less frequent update
   logical :: needs_IO_for_data = .false.              !< Is any i/o needed for OBCs
   logical :: zero_vorticity = .false.                 !< If True, sets relative vorticity to zero on open boundaries.
   logical :: freeslip_vorticity = .false.             !< If True, sets normal gradient of tangential velocity to zero
@@ -3897,6 +3899,10 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
     allocate(h_stack(GV%ke))
     h_stack(:) = 0.0
     do m = 1,segment%num_fields
+      !This field may not require a high frequency OBC segment update and might be allowed
+      !a less frequent update as set by the parameter update_OBC_period_max in MOM.F90.  
+      !Cycle if it is not the time to update OBC segment data for this field.
+      if (trim(segment%field(m)%genre) == 'obgc' .and. (.not. OBC%update_OBC_seg_data)) cycle  
       if (segment%field(m)%fid > 0) then
         siz(1)=size(segment%field(m)%buffer_src,1)
         siz(2)=size(segment%field(m)%buffer_src,2)


### PR DESCRIPTION
You can set the obgc obc seg data update period via a MOM_override. 
E.g., :
#override DT_OBC_SEG_UPDATE_OBGC = 7200.0

Here's the resulting timings for a 1 month run on c4

     ncores      576       1152      2304
NWA_physical      4.4       6.5       9.1 sypd
NWA_COBALT_300    1.2       1.6       1.8 sypd (seg update 300secs for all)
NWA_COBALT_3600   1.7       2.7       3.7 sypd (seg update 3600secs for bgc)
NWA_COBALT_7200   1.8       2.8       3.9 sypd (seg update 7200secs for bgc)
NWA_COBALT_86400  1.8       2.9       4.1 sypd (seg update 86400secs for bgc)

