### PR TITLE
fix restart issues with OBC experiments

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -1036,7 +1036,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
 
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB
-
   real, dimension(SZI_(CS%G),SZJ_(CS%G),SZK_(CS%G)+1) :: eta_por ! layer interface heights
                                                     !! for porous topo. [Z ~> m or 1/eta_to_m]
   G => CS%G ; GV => CS%GV ; US => CS%US ; IDs => CS%IDs
@@ -1082,6 +1081,17 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
     call disable_averaging(CS%diag)
   endif
 
+  !OBC segment data update for some fields can be less frequent than others 
+  if(associated(CS%OBC)) then
+    CS%OBC%update_OBC_seg_data = .false.
+    if (CS%dt_obc_seg_period == 0.0) CS%OBC%update_OBC_seg_data = .true.
+    if (CS%dt_obc_seg_period > 0.0) then
+     if (Time_local >= CS%dt_obc_seg_time) then  !### Change >= to > here.
+      CS%OBC%update_OBC_seg_data = .true.
+      CS%dt_obc_seg_time = CS%dt_obc_seg_time + CS%dt_obc_seg_interval
+     endif
+    endif
+  endif
 
   if (CS%do_dynamics .and. CS%split) then !--------------------------- start SPLIT
     ! This section uses a split time stepping scheme for the dynamic equations,
@@ -1093,17 +1103,6 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
       if (Time_local >= CS%dtbt_reset_time) then  !### Change >= to > here.
         calc_dtbt = .true.
         CS%dtbt_reset_time = CS%dtbt_reset_time + CS%dtbt_reset_interval
-      endif
-    endif
-    !OBC segment data update for some fields can be less frequent than others 
-    if(associated(CS%OBC)) then
-      CS%OBC%update_OBC_seg_data = .false.
-      if (CS%dt_obc_seg_period == 0.0) CS%OBC%update_OBC_seg_data = .true.
-      if (CS%dt_obc_seg_period > 0.0) then
-       if (Time_local >= CS%dt_obc_seg_time) then  !### Change >= to > here.
-        CS%OBC%update_OBC_seg_data = .true.
-        CS%dt_obc_seg_time = CS%dt_obc_seg_time + CS%dt_obc_seg_interval
-       endif
       endif
     endif
 
@@ -2009,14 +2008,15 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
                  "DTBT will be set every dynamics time step. The default "//&
                  "is set by DT_THERM.  This is only used if SPLIT is true.", &
                  units="s", default=default_val, do_not_read=(dtbt > 0.0))
-
-    CS%dt_obc_seg_period = -1.0
-    call get_param(param_file, "MOM", "DT_OBC_SEG_UPDATE_OBGC", CS%dt_obc_seg_period, &
-                 "The time between OBC segment data updates for OBGC tracers. "//&
-                 "The default is set to DT.  This is only used if SPLIT is true.", &
-                 units="s", default=CS%dt)
-     
   endif
+
+  CS%dt_obc_seg_period = -1.0
+  call get_param(param_file, "MOM", "DT_OBC_SEG_UPDATE_OBGC", CS%dt_obc_seg_period, &
+               "The time between OBC segment data updates for OBGC tracers. "//&
+               "This must be an integer multiple of DT and DT_THERM. "//&
+               "The default is set to DT.", &
+               units="s", default=CS%dt)
+     
 
   ! This is here in case these values are used inappropriately.
   use_frazil = .false. ; bound_salinity = .false.
@@ -2740,19 +2740,6 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
         CS%dtbt_reset_time = CS%dtbt_reset_time - CS%dtbt_reset_interval
       endif
     endif
-    !Set OBC segment data update period
-    if (associated(CS%OBC) .and. CS%dt_obc_seg_period > 0.0) then
-      CS%dt_obc_seg_interval = real_to_time(CS%dt_obc_seg_period)
-      ! Set dt_obc_seg_time to be the next even multiple of dt_obc_seg_interval.
-      CS%dt_obc_seg_time = Time_init + CS%dt_obc_seg_interval * &
-                                 ((Time - Time_init) / CS%dt_obc_seg_interval)
-      if ((CS%dt_obc_seg_time > Time) .and. CS%OBC%update_OBC_seg_data) then
-        ! Back up dtbt_reset_time one interval to force dtbt to be calculated,
-        ! because the restart was not aligned with the interval to recalculate
-        ! dtbt, and dtbt was not read from a restart file.
-        CS%dt_obc_seg_time = CS%dt_obc_seg_time - CS%dt_obc_seg_interval
-      endif
-    endif
   elseif (CS%use_RK2) then
     call initialize_dyn_unsplit_RK2(CS%u, CS%v, CS%h, Time, G, GV, US,     &
             param_file, diag, CS%dyn_unsplit_RK2_CSp,                      &
@@ -2765,6 +2752,12 @@ subroutine initialize_MOM(Time, Time_init, param_file, dirs, CS, restart_CSp, &
             CS%ADp, CS%CDp, MOM_internal_state, CS%OBC,                    &
             CS%update_OBC_CSp, CS%ALE_CSp, CS%set_visc_CSp, CS%visc, dirs, &
             CS%ntrunc, cont_stencil=CS%cont_stencil)
+  endif
+
+  !Set OBC segment data update period
+  if (associated(CS%OBC) .and. CS%dt_obc_seg_period > 0.0) then
+    CS%dt_obc_seg_interval = real_to_time(CS%dt_obc_seg_period)
+    CS%dt_obc_seg_time = Time + CS%dt_obc_seg_interval
   endif
 
   call callTree_waypoint("dynamics initialized (initialize_MOM)")

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -5234,12 +5234,31 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
   real :: fac1            ! The denominator of the expression for tracer updates [nondim]
   integer :: i, j, k, m, n, ntr, nz
   integer :: ishift, idir, jshift, jdir
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h1
+  real, dimension(SZIB_(G),SZJ_(G),SZK_(GV)) :: uhr1
+  real, dimension(SZI_(G),SZJB_(G),SZK_(GV)) :: vhr1
 
+  if(.NOT. associated(OBC)) return
   nz = GV%ke
   ntr = Reg%ntr
-  if (associated(OBC)) then ; if (OBC%OBC_pe) then ; do n=1,OBC%number_of_segments
-    segment=>OBC%segment(n)
-    if (.not. associated(segment%tr_Reg)) cycle
+  !Input arrays h,uhr,vhr have not had halo updates since they were last updated outside this routine.
+  !This was causing restart issues for experiments that include tracers with reservoirs.
+  !We need to perform halo updates for input arrays, since they are intent(in) they cannot be modified.
+  !Hence we make copies of them.
+  h1=h
+  uhr1=uhr
+  vhr1=vhr
+  call pass_var(h1, G%Domain)
+  call pass_vector(uhr1,vhr1, G%Domain)
+
+  if (OBC%OBC_pe) then ; do n=1,OBC%number_of_segments
+   segment=>OBC%segment(n)
+   if (.not. associated(segment%tr_Reg)) cycle
+   do m=1,ntr
+    if (.not. allocated(segment%tr_Reg%Tr(m)%tres)) cycle
+    !OBGC tracers may have less frequent segment updates
+    if (trim(segment%field(m)%genre) == 'obgc' .and. (.not. OBC%update_OBC_seg_data)) cycle
+
     if (segment%is_E_or_W) then
       I = segment%HI%IsdB
       do j=segment%HI%jsd,segment%HI%jed
@@ -5253,17 +5272,17 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
         ! Can keep this or take it out, either way
         if (G%mask2dT(I+ishift,j) == 0.0) cycle
         ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
-        do m=1,ntr ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then ; do k=1,nz
-          u_L_out = max(0.0, (idir*uhr(I,j,k))*segment%Tr_InvLscale_out*segment%field(m)%resrv_lfac_out / &
-                    ((h(i+ishift,j,k) + GV%H_subroundoff)*G%dyCu(I,j)))
-          u_L_in  = min(0.0, (idir*uhr(I,j,k))*segment%Tr_InvLscale_in*segment%field(m)%resrv_lfac_in  / &
-                    ((h(i+ishift,j,k) + GV%H_subroundoff)*G%dyCu(I,j)))
+        do k=1,nz
+          u_L_out = max(0.0, (idir*uhr1(I,j,k))*segment%Tr_InvLscale_out*segment%field(m)%resrv_lfac_out / &
+                    ((h1(i+ishift,j,k) + GV%H_subroundoff)*G%dyCu(I,j)))
+          u_L_in  = min(0.0, (idir*uhr1(I,j,k))*segment%Tr_InvLscale_in*segment%field(m)%resrv_lfac_in  / &
+                    ((h1(i+ishift,j,k) + GV%H_subroundoff)*G%dyCu(I,j)))
           fac1 = 1.0 + (u_L_out-u_L_in)
           segment%tr_Reg%Tr(m)%tres(I,j,k) = (1.0/fac1)*(segment%tr_Reg%Tr(m)%tres(I,j,k) + &
                             (u_L_out*Reg%Tr(m)%t(I+ishift,j,k) - &
                              u_L_in*segment%tr_Reg%Tr(m)%t(I,j,k)))
           if (allocated(OBC%tres_x)) OBC%tres_x(I,j,k,m) = segment%tr_Reg%Tr(m)%tres(I,j,k)
-        enddo ; endif ; enddo
+        enddo
       enddo
     elseif (segment%is_N_or_S) then
       J = segment%HI%JsdB
@@ -5278,20 +5297,21 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
         ! Can keep this or take it out, either way
         if (G%mask2dT(i,j+jshift) == 0.0) cycle
         ! Update the reservoir tracer concentration implicitly using a Backward-Euler timestep
-        do m=1,ntr ; if (allocated(segment%tr_Reg%Tr(m)%tres)) then ; do k=1,nz
-          v_L_out = max(0.0, (jdir*vhr(i,J,k))*segment%Tr_InvLscale_out*segment%field(m)%resrv_lfac_out / &
-                    ((h(i,j+jshift,k) + GV%H_subroundoff)*G%dxCv(i,J)))
-          v_L_in  = min(0.0, (jdir*vhr(i,J,k))*segment%Tr_InvLscale_in*segment%field(m)%resrv_lfac_in  / &
-                    ((h(i,j+jshift,k) + GV%H_subroundoff)*G%dxCv(i,J)))
+        do k=1,nz
+          v_L_out = max(0.0, (jdir*vhr1(i,J,k))*segment%Tr_InvLscale_out*segment%field(m)%resrv_lfac_out / &
+                    ((h1(i,j+jshift,k) + GV%H_subroundoff)*G%dxCv(i,J)))
+          v_L_in  = min(0.0, (jdir*vhr1(i,J,k))*segment%Tr_InvLscale_in*segment%field(m)%resrv_lfac_in  / &
+                    ((h1(i,j+jshift,k) + GV%H_subroundoff)*G%dxCv(i,J)))
           fac1 = 1.0 + (v_L_out-v_L_in)
           segment%tr_Reg%Tr(m)%tres(i,J,k) = (1.0/fac1)*(segment%tr_Reg%Tr(m)%tres(i,J,k) + &
                             (v_L_out*Reg%Tr(m)%t(i,J+jshift,k) - &
                              v_L_in*segment%tr_Reg%Tr(m)%t(i,J,k)))
           if (allocated(OBC%tres_y)) OBC%tres_y(i,J,k,m) = segment%tr_Reg%Tr(m)%tres(i,J,k)
-        enddo ; endif ; enddo
+        enddo
       enddo
     endif
-  enddo ; endif ; endif
+   enddo !m=1,ntr
+  enddo ; endif
 
 end subroutine update_segment_tracer_reservoirs
 

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -64,6 +64,7 @@ public update_OBC_ramp
 public rotate_OBC_config
 public rotate_OBC_init
 public initialize_segment_data
+public setup_OBC_tracer_reservoirs
 
 integer, parameter, public :: OBC_NONE = 0      !< Indicates the use of no open boundary
 integer, parameter, public :: OBC_SIMPLE = 1    !< Indicates the use of a simple inflow open boundary
@@ -4809,7 +4810,7 @@ subroutine fill_obgc_segments(G, GV, OBC, tr_ptr, tr_name)
     endif
     segment%tr_Reg%Tr(nt)%tres(:,:,:) = segment%tr_Reg%Tr(nt)%t(:,:,:)
   enddo
-  call setup_OBC_tracer_reservoirs(GV, OBC, .true.) ! Skip T and S to avoid restart bug
+!  call setup_OBC_tracer_reservoirs(GV, OBC, .true.) ! Skip T and S to avoid restart bug
 end subroutine fill_obgc_segments
 
 subroutine fill_temp_salt_segments(G, GV, OBC, tv)
@@ -4868,7 +4869,7 @@ subroutine fill_temp_salt_segments(G, GV, OBC, tv)
     segment%tr_Reg%Tr(2)%tres(:,:,:) = segment%tr_Reg%Tr(2)%t(:,:,:)
   enddo
 
-  call setup_OBC_tracer_reservoirs(GV, OBC)
+!  call setup_OBC_tracer_reservoirs(GV, OBC)
 end subroutine fill_temp_salt_segments
 
 !> Find the region outside of all open boundary segments and

--- a/src/core/MOM_open_boundary.F90
+++ b/src/core/MOM_open_boundary.F90
@@ -4220,6 +4220,8 @@ subroutine update_OBC_segment_data(G, GV, US, OBC, tv, h, Time)
     ! Start second loop to update all fields now that data for all fields are available.
     ! (split because tides depend on multiple variables).
     do m = 1,segment%num_fields
+      !cycle if it is not the time to update OBGC tracers from source
+      if (trim(segment%field(m)%genre) == 'obgc' .and. (.not. OBC%update_OBC_seg_data)) cycle
       ! if (segment%field(m)%fid>0) then
       ! calculate external BT velocity and transport if needed
       if (trim(segment%field(m)%name) == 'U' .or. trim(segment%field(m)%name) == 'V') then
@@ -5256,8 +5258,6 @@ subroutine update_segment_tracer_reservoirs(G, GV, uhr, vhr, h, OBC, dt, Reg)
    if (.not. associated(segment%tr_Reg)) cycle
    do m=1,ntr
     if (.not. allocated(segment%tr_Reg%Tr(m)%tres)) cycle
-    !OBGC tracers may have less frequent segment updates
-    if (trim(segment%field(m)%genre) == 'obgc' .and. (.not. OBC%update_OBC_seg_data)) cycle
 
     if (segment%is_E_or_W) then
       I = segment%HI%IsdB

--- a/src/initialization/MOM_state_initialization.F90
+++ b/src/initialization/MOM_state_initialization.F90
@@ -24,7 +24,7 @@ use MOM_open_boundary, only : OBC_NONE, OBC_SIMPLE
 use MOM_open_boundary, only : open_boundary_query
 use MOM_open_boundary, only : set_tracer_data, initialize_segment_data
 use MOM_open_boundary, only : open_boundary_test_extern_h
-use MOM_open_boundary, only : fill_temp_salt_segments
+use MOM_open_boundary, only : fill_temp_salt_segments,setup_OBC_tracer_reservoirs
 use MOM_open_boundary, only : update_OBC_segment_data
 !use MOM_open_boundary, only : set_3D_OBC_data
 use MOM_grid_initialize, only : initialize_masks, set_grid_metrics
@@ -401,9 +401,10 @@ subroutine MOM_initialize_state(u, v, h, tv, Time, G, GV, US, PF, dirs, &
       end select
     endif
   endif  ! not from_Z_file.
-  if (use_temperature .and. use_OBC) &
+  if (use_temperature .and. use_OBC) then 
     call fill_temp_salt_segments(G, GV, OBC, tv)
-
+    call setup_OBC_tracer_reservoirs(GV, OBC)
+  endif
   ! The thicknesses in halo points might be needed to initialize the velocities.
   if (new_sim) call pass_var(h, G%Domain)
 


### PR DESCRIPTION
The NWA OBC experiments suffer from a restart issue. There are a few bugs mixed together that were causing these and this update tries to address them. There were two basic issues; 1. A few missing halo updates causing the physical as well as obgc experiments not to reproduce
2. Bad logic for determining the update time for obgc tracers that use a segment updating period larger than DT.

Here's how to address  these:

1. Apply halo updates to h,uhr,vhr before use in tracer reservoir update
          fixes the restart issue for the physical model T&S
          fixes the restart issue for the BGC tracers when segment update period  = DT
2. Fix the restart issue for BGC tracers when segment update period > DT
          fixes the logic for setting the update time (it was not correct)
          Note that DT_OBC_SEG_UPDATE_OBGC has to be an integer multiple of DT and DT_THERM !